### PR TITLE
use custom separator for targets and help text

### DIFF
--- a/_tips/2020/07/01/list-makefile-targets.md
+++ b/_tips/2020/07/01/list-makefile-targets.md
@@ -36,8 +36,8 @@ Then, we will use the `grep` and `sed` command to get the name of the target and
 
 help:
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
-	| sed -n 's/^\(.*\): \(.*\)##\(.*\)/\1\3/p' \
-	| column -t  -s ' '
+	| sed -n 's/^\(.*\): \(.*\)##\(.*\)/\1{{MAKEFILE_TARGET_SEPARATOR}}\3/p' \
+	| column -t  -s '{{MAKEFILE_TARGET_SEPARATOR}}'
 ```
 
 We will also set the `.PHONY` and the `.DEFAULT_GOAL` variables. The last one will make `help` the default target when running `make` without a specific target.


### PR DESCRIPTION
if `column` is run against spaces (`'  '`), then it winds up making a column for every word in the help text. by replacing the target name and help text with a custom separator string that's highly unlikely to appear in an actual makefile target help, column is able to split at just that spot.

before: 
```
❯ make
help           these  help      instructions
lint_frontend  run    frontend  lint
test_frontend  run    frontend  tests
```

after:
```
❯ make
help            these help instructions
lint_frontend   run frontend lint
test_frontend   run frontend tests
```